### PR TITLE
Use docker compose instead of docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ You need docker with docker compose, this probably only works on Linux and Intel
 
 Run `./setup.sh` that will create many certificates, JWT tokens etc
 
-Run `docker-compose up --scale server.choria=10` to run 10 Choria servers.
+Run `docker compose up --scale server.choria=10` to run 10 Choria servers.
 
-Run `docker-compose exec client.choria bash -l` to get a shell.
+Run `docker compose exec client.choria bash -l` to get a shell.
 
 Once in the shell do:
 


### PR DESCRIPTION
Problem:
On bullseye with the Docker repositories enabled, docker-compose results
in command not found.  apt install docker-compose works and provides the
command but it's ancient in bullseye and doesn't work with this compose
file.

Solution:
Suggest the user runs `docker compose` instead which uses the
docker-compose-plugin package, which installs
/usr/libexec/docker/cli-plugins/docker-compose

Result:

This works now on Debian 11 with `Docker Compose version v2.16.0`

```
./setup.sh
docker compose up --scale server.choria=10
```

```
❯ docker compose exec client.choria bash -l
[choria@client /]$ choria login
? Username:  choria
? Password:  ******
Token saved to /home/choria/.config/choria/client.jwt
```

```
choria req choria_util info
```

```
Finished processing 10 / 10 hosts in 395ms
```
